### PR TITLE
Remove railtie as a dependency if you're not running Rails

### DIFF
--- a/ftl-serializer.gemspec
+++ b/ftl-serializer.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 5"
   spec.add_dependency "oj", '>= 2'
 
+  spec.add_development_dependency "railties", ">= 5"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"

--- a/ftl-serializer.gemspec
+++ b/ftl-serializer.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", ">= 5"
   spec.add_dependency "activesupport", ">= 5"
   spec.add_dependency "oj", '>= 2'
 

--- a/lib/ftl-serializer.rb
+++ b/lib/ftl-serializer.rb
@@ -2,7 +2,7 @@
 
 require "ftl/version"
 require "ftl/serializer"
-require "ftl/railtie"
+require "ftl/railtie" if defined?(Rails)
 require "ftl/errors"
 require "ftl/configuration"
 require "ftl/serializer/base"

--- a/lib/ftl-serializer.rb
+++ b/lib/ftl-serializer.rb
@@ -3,6 +3,7 @@
 require "ftl/version"
 require "ftl/serializer"
 require "ftl/railtie" if defined?(Rails)
+require "ftl/load_and_bootstrap"
 require "ftl/errors"
 require "ftl/configuration"
 require "ftl/serializer/base"

--- a/lib/ftl-serializer.rb
+++ b/lib/ftl-serializer.rb
@@ -3,7 +3,6 @@
 require "ftl/version"
 require "ftl/serializer"
 require "ftl/railtie" if defined?(Rails)
-require "ftl/load_and_bootstrap"
 require "ftl/errors"
 require "ftl/configuration"
 require "ftl/serializer/base"

--- a/lib/ftl/railtie.rb
+++ b/lib/ftl/railtie.rb
@@ -13,20 +13,7 @@ module FTL
       end
 
       ftl_reloader = app.config.file_watcher.new([], reload_paths) do
-        FTL::Configuration.serializer_paths.map do |path|
-          Dir.glob("#{path}/**/*.rb").each do |file|
-            begin
-              if Rails.env.development? || Rails.env.test?
-                load file
-              else
-                require file
-              end
-            rescue => e
-              warn "can't load '#{file}' file (#{e.message})!"
-            end
-          end
-        end
-
+        FTL::Serializer.load_from_configured_paths
         FTL::Serializer.bootstrap!
       end
 

--- a/lib/ftl/serializer.rb
+++ b/lib/ftl/serializer.rb
@@ -12,6 +12,22 @@ module FTL
       @serializers
     end
 
+    def self.load_from_configured_paths
+      FTL::Configuration.serializer_paths.map do |path|
+        Dir.glob("#{path}/**/*.rb").each do |file|
+          begin
+            if defined?(Rails) && (Rails.env.development? || Rails.env.test?)
+              load file
+            else
+              require file
+            end
+          rescue => e
+            warn "can't load '#{file}' file (#{e.message})!"
+          end
+        end
+      end
+    end
+
     def self.bootstrap!
       return nil unless @serializers
       @serializers.each do |klass|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require "bundler/setup"
 require "ftl-serializer"
+require "ftl/railtie"
 FTL::Configuration.serializer_paths = ["spec/ftl/test_examples"]
 require 'ftl/test_examples/basic_serializer'
 require 'active_support/testing/time_helpers'


### PR DESCRIPTION
This removes Railtie as a dependency if you're not running Rails (say if you wanted to include FTL in a gem or something). 

If you ARE running Rails though it should just work.