### PR TITLE
Bump rake version

### DIFF
--- a/ftl-serializer.gemspec
+++ b/ftl-serializer.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 5"
   spec.add_dependency "oj", '>= 2'
 
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-byebug"

--- a/ftl-serializer.gemspec
+++ b/ftl-serializer.gemspec
@@ -39,6 +39,4 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "pry-byebug"
 end


### PR DESCRIPTION
This updates the development rake dependency to a recent version without any security vulnerabilities.